### PR TITLE
Update Shower GitHub link

### DIFF
--- a/data.json
+++ b/data.json
@@ -44,7 +44,7 @@
 			"url": "https://shwr.me",
 			"image": "https://avatars2.githubusercontent.com/u/2495549?v=3&s=200",
 			"description": "HTML presentation engine",
-			"github": "pepelsbey/shower"
+			"github": "shower/shower"
 		},
 		{
 			"name": "Sorttable",


### PR DESCRIPTION
Current link is a 404. Updated it with the correct one: https://github.com/shower/shower 
