### PR TITLE
Add EQCSS to the list

### DIFF
--- a/data.json
+++ b/data.json
@@ -107,6 +107,13 @@
 			"url": "https://github.com/stefanoio/togglr",
 			"description": "Add/remove/toggle classes on specific targets on user input (click).",
 			"github": "stefanoio/togglr"
+		},
+		{
+			"name": "eqcss",
+			"author": "Tommy Hodgins & Maxime Euziere",
+			"url": "http://elementqueries.com",
+			"description": "A CSS extension for element queries, scoped styles, & special selectors like $parent and $this",
+			"github": "eqcss/eqcss"
 		}
 	]
 }

--- a/data.json
+++ b/data.json
@@ -112,6 +112,7 @@
 			"name": "eqcss",
 			"author": "Tommy Hodgins & Maxime Euziere",
 			"url": "http://elementqueries.com",
+			"image": "https://raw.githubusercontent.com/eqcss/eqcss/gh-pages/eqcss-logo.png",
 			"description": "A CSS extension for element queries, scoped styles, & special selectors like $parent and $this",
 			"github": "eqcss/eqcss"
 		}


### PR DESCRIPTION
Reasoning: It's a small, plain JS plugin that can be dropped into any HTML to enhance CSS in all browsers IE8 and up. The designer writing the CSS enhanced by this plugin doesn't need to touch JavaScript in order to make use of the features.
