### PR TITLE
Proposed Numeric input

### DIFF
--- a/data.json
+++ b/data.json
@@ -56,6 +56,13 @@
 			"github": "LeadDyno/intercooler-js"
 		},
 		{
+			"name": "Numeric input",
+			"author": "filamentgroup",
+			"url": "https://github.com/filamentgroup/formcore",
+			"description": "A number of features around normalizing the behavior of <input type=\"number\"> form fields.",
+			"github": "filamentgroup/formcore"
+	        },
+		{
 			"name": "Packery",
 			"author": "metafizzy",
 			"url": "http://packery.metafizzy.co",


### PR DESCRIPTION
_Numeric input_ is not exactly a library itself, is part of the _formcore_ developed by the filament group. I let you know in case you are interested to include it, but actually since it isn't a library itself feels a little weird to include it.
