### PR TITLE
Added SimplyEdit, a website editor

### DIFF
--- a/data.json
+++ b/data.json
@@ -154,6 +154,13 @@
 			"github": "55sketch/simple-rss"
 		},
 		{
+			"name": "SimplyEdit",
+			"author": "Yvo Brevoort",
+			"url": "https://simplyedit.io/",
+			"description": "A website editor and view system. Its like Wordpress running in your browser. No programming needed.",
+			"image": "https://simplyedit.io/img/se-edit-animation-3.gif"
+		},
+		{
 			"name": "Sorttable",
 			"author": "stuartlangridge",
 			"url": "http://www.kryogenix.org/code/browser/sorttable",


### PR DESCRIPTION
SimplyEdit is a tool that plugs in to your HTML and makes your website editable. Data is stored through a single PUT of a json file. It uses data-attributes and <template> tags to fill the HTML with the data.