### PR TITLE
Fix Library Image Sizing/Object-Fit

### DIFF
--- a/style.css
+++ b/style.css
@@ -88,7 +88,7 @@ article:target {
 	article img {
 		width: 8.5em;
 		height: 8.5em;
-		object-fit: cover;
+		object-fit: contain;
 		float: right;
 		margin-left: .5em;
 		border-radius: .3em;


### PR DESCRIPTION
Library images' object-fit was set to `cover` when (I believe) the intention was to set it to `contain`, which correctly displays each library's image. (A good example: the AMP logo will now display correctly.)